### PR TITLE
Fix base URL for GitHub Pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,8 +24,8 @@ description: >- # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
-baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "/100daysofcoding" # the subpath of your site, e.g. /blog
+url: "https://ralphp1121.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll
 


### PR DESCRIPTION
## Summary
- set `_config.yml` base URL and hostname for GitHub Pages

## Testing
- `bundle exec jekyll build` *(fails: undefined method `untaint' for "Welcome to Jekyll!":String)*

------
https://chatgpt.com/codex/tasks/task_e_689568e6845c83248915464ff4cc0f1f